### PR TITLE
Properly Handle Opening Base64 Thumbnails

### DIFF
--- a/viewimage.js
+++ b/viewimage.js
@@ -26,3 +26,14 @@ var img = imgs.forEach(function(img){
         window.open(img.src);
     }
 });
+
+var imgDatas = document.querySelectorAll(".irc_mut");
+var imgData = imgDatas.forEach(function(imgData){
+    if(isElementVisible(imgData)){
+		var image = new Image();
+        image.src = imgData.currentSrc;
+
+        var w = window.open("");
+        w.document.write(image.outerHTML);
+    }
+});


### PR DESCRIPTION
Fix for when google displays a base64 thumbnail instead of an img with a src URL.